### PR TITLE
Update joomla2wp_mig_auth.php

### DIFF
--- a/joomla2wp_mig_auth.php
+++ b/joomla2wp_mig_auth.php
@@ -60,7 +60,8 @@ function joomla_mig_auth( $user, $username, $password ) {
 
 function auth_joomla_phpass( $username, $password, $joomlapass ) {
         // Use PHPass's portable hashes with a cost of 10.
-        $phpass = new PasswordHash(10, true);
+        require_once ABSPATH . WPINC . '/class-phpass.php';
+	$phpass = new PasswordHash(10, true);
 
         $password = stripslashes($password);
 


### PR DESCRIPTION
With this change, I don't get "Class not found" error in wordpress 5.4